### PR TITLE
Fix vault list to be in a consistent order

### DIFF
--- a/templates/master.conf.erb
+++ b/templates/master.conf.erb
@@ -12,6 +12,6 @@ post-server: /etc/dirvish/post-server
 <% end -%>
 
 Runall:
-<% scope.lookupvar('::dirvish::vaults').keys.each do |vault| -%>
+<% scope.lookupvar('::dirvish::vaults').keys.sort.each do |vault| -%>
   <%= vault %>
 <% end -%>


### PR DESCRIPTION
Should fix this regular reordering of our dirvish configuration file:

<pre>
Notice: /File[/etc/dirvish/master.conf]/content: 
--- /etc/dirvish/master.conf    2015-04-10 07:50:25.342158834 +0000
+++ /tmp/puppet-file20150410-29328-15d0wz2-0    2015-04-10 09:39:04.434172545 +0000
@@ -10,7 +10,7 @@
 post-server: /etc/dirvish/post-server
 
 Runall:
-  redmine
-  ci
   ci-jenkins
+  ci
   puppetmaster
+  redmine
</pre>
